### PR TITLE
Custom parameter section name added

### DIFF
--- a/sphinxcontrib/napoleon/docstring.py
+++ b/sphinxcontrib/napoleon/docstring.py
@@ -693,11 +693,20 @@ class GoogleDocstring(UnicodeMixin):
 
     def _parse_parameters_section(self, section):
         # type: (unicode) -> List[unicode]
+
+        labels = {
+            'args': _('Parameters'),
+            'arguments': _('Parameters'),
+            'parameters': _('Parameters'),
+        }  # type: Dict[unicode, unicode]
+        use_admonition = self._config.napoleon_use_admonition_for_examples
+        label = labels.get(section.lower(), section)
+
         fields = self._consume_fields()
         if self._config.napoleon_use_param:
             return self._format_docutils_params(fields)
         else:
-            return self._format_fields(_('Parameters'), fields)
+            return self._format_fields(label, fields)
 
     def _parse_raises_section(self, section):
         # type: (unicode) -> List[unicode]

--- a/sphinxcontrib/napoleon/docstring.py
+++ b/sphinxcontrib/napoleon/docstring.py
@@ -701,7 +701,7 @@ class GoogleDocstring(UnicodeMixin):
         }  # type: Dict[unicode, unicode]
         use_admonition = self._config.napoleon_use_admonition_for_examples
         label = labels.get(section.lower(), section)
-
+        print("YOOOO")
         fields = self._consume_fields()
         if self._config.napoleon_use_param:
             return self._format_docutils_params(fields)

--- a/sphinxcontrib/napoleon/docstring.py
+++ b/sphinxcontrib/napoleon/docstring.py
@@ -693,7 +693,6 @@ class GoogleDocstring(UnicodeMixin):
 
     def _parse_parameters_section(self, section):
         # type: (unicode) -> List[unicode]
-
         labels = {
             'args': _('Parameters'),
             'arguments': _('Parameters'),
@@ -701,7 +700,7 @@ class GoogleDocstring(UnicodeMixin):
         }  # type: Dict[unicode, unicode]
         use_admonition = self._config.napoleon_use_admonition_for_examples
         label = labels.get(section.lower(), section)
-        print("YOOOO")
+
         fields = self._consume_fields()
         if self._config.napoleon_use_param:
             return self._format_docutils_params(fields)


### PR DESCRIPTION
When using 
```
napoleon_use_param = False
napoleon_custom_sections = [('Custom name', 'Parameters')]
```
The `Custom name` section will have the formatting of the `Parameters` section, but the custom name. This follows the way the `Example` section worked (it already takes the custom name).

This was requested also in this issue: https://github.com/sphinx-contrib/napoleon/issues/2