### PR TITLE
Fix warning about to-be-deprecated import

### DIFF
--- a/sphinxcontrib/napoleon/docstring.py
+++ b/sphinxcontrib/napoleon/docstring.py
@@ -13,7 +13,7 @@
 
 import inspect
 import re
-from collections import Callable
+from collections.abc import Callable
 from functools import partial
 
 from six import string_types, u


### PR DESCRIPTION
Running the test suite gave me a warning that importing `Callables` directly from `collections` will be deprecated in Python 3.8. This fixes the source of this warning.

Confirmed that all of the tests pass with this change.