### PR TITLE
Fix output for multi-line and multi-parameter return/yield strings

### DIFF
--- a/tests/napoleon/test_docstring.py
+++ b/tests/napoleon/test_docstring.py
@@ -220,6 +220,40 @@ class GoogleDocstringTest(BaseDocstringTest):
                   description of return value
         """
     ), (
+    #     """
+    #     Single line summary
+
+    #     Return:
+    #       str: Extended
+    #       description of return value
+    #       bool: Other
+    #       return value
+    #     """,
+    #     """
+    #     Single line summary
+
+    #     :returns: *str* -- Extended
+    #               description of return value
+
+    #               *bool* -- Other
+    #               return value
+
+    #     """
+    # ), (
+    #     """
+    #     Single line summary
+
+    #     Returns:
+    #       str: Extended
+    #         description of return value
+    #     """,
+    #     """
+    #     Single line summary
+
+    #     :returns: *str* -- Extended
+    #               description of return value
+    #     """
+    # ), (
         """
         Single line summary
 
@@ -346,6 +380,8 @@ class GoogleDocstringTest(BaseDocstringTest):
         for docstring, expected in self.docstrings:
             actual = str(GoogleDocstring(dedent(docstring), config))
             expected = dedent(expected)
+            if (expected != actual):
+                print(actual)
             self.assertEqual(expected, actual)
 
     def test_parameters_with_class_reference(self):
@@ -1140,12 +1176,17 @@ class NumpyDocstringTest(BaseDocstringTest):
         str
             Extended
             description of yielded value
+        bool
+            Extended
+            description of yielded value
         """,
         """
         Single line summary
 
-        :Yields: *str* -- Extended
-                 description of yielded value
+        :Yields: * *str* -- Extended
+                   description of yielded value
+                 * *bool* -- Extended
+                   description of yielded value
         """
     ), (
         """


### PR DESCRIPTION
Closes #12.

The output of multi-line return and yield statements can end up garbled and showing as bulletted lists when they shouldn't be. #12 captures one example of this, but I found that other methods of documenting the return values can cause similar errors. 

Currently opening this as a draft, I would appreciate any critiques of the test cases that I am adding as I progress; I'll work on making sure that all of the test cases pass once it's clear that I'm testing for the right conditions/correct output.