### PR TITLE
Updated import to support Python 3.10

### DIFF
--- a/sphinxcontrib/napoleon/docstring.py
+++ b/sphinxcontrib/napoleon/docstring.py
@@ -13,7 +13,10 @@
 
 import inspect
 import re
-from collections import Callable
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
 from functools import partial
 
 from six import string_types, u


### PR DESCRIPTION
This code change should create compatibility with Python 3.10 while falling back on the former implementation to ensure backwards compatibility.