### PR TITLE
Fix extension name

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -68,7 +68,7 @@ Getting Started
        # conf.py
 
        # Add napoleon to the extensions list
-       extensions = ['sphinxcontrib.napoleon']
+       extensions = ['sphinx.ext.napoleon']
 
 3. Use `sphinx-apidoc` to build your API documentation::
 


### PR DESCRIPTION
Extension name was changed to `sphinx.ext.napoleon` since the original one was causing following error:
`Could not import extension sphinxcontrib.napoleon (exception: cannot import name 'Callable' from 'collections' (/opt/homebrew/Cellar/python@3.11/3.11.1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/collections/__init__.py))`

When `make html` script was called.